### PR TITLE
Wrong settings when multiple shops are added

### DIFF
--- a/lib/paypal.coffee
+++ b/lib/paypal.coffee
@@ -1,6 +1,6 @@
 Meteor.Paypal =
   payflowAccountOptions: ->
-    settings = ReactionCore.Collections.Packages.findOne(name: "reaction-paypal").settings
+    settings = ReactionCore.Collections.Packages.findOne({name: "reaction-paypal", shopId: ReactionCore.getShopId(), enabled: true}).settings
     if settings?.payflow_mode is true then mode = "live" else mode = "sandbox"
     options =
       mode: mode
@@ -10,7 +10,7 @@ Meteor.Paypal =
     return options
 
   expressCheckoutAccountOptions: ->
-    settings = ReactionCore.Collections.Packages.findOne(name: "reaction-paypal").settings
+    settings = ReactionCore.Collections.Packages.findOne({name: "reaction-paypal", shopId: ReactionCore.getShopId(), enabled: true}).settings
     if settings?.express_mode is true then mode = "production" else mode = "sandbox"
 
     options =


### PR DESCRIPTION
Hi Aaron, 
The reaction-paypal was not working correctly for me and after some debugging I found that the setting  values are not correctly extracted from the DB.
When there are multiple shops in the DB there will be multiple reacton-paypal packages and we should pick the one based on the Reaction Core's shopId, and also it should be enabled I think.

I hope I figured this out correctly if not let me know and I will adjust it.
Bogi