### PR TITLE
Refunds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.js]
+max_line_length = 160
+indent_brace_style = 1TBS
+spaces_around_operators = true
+quote_type = double
+insert_final_newline = true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,185 @@
+{
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "node": true,
+    "meteor": true,
+  },
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "blockBindings": true,
+    "classes": true,
+    "defaultParams": true,
+    "destructuring": true,
+    "forOf": true,
+    "generators": false,
+    "modules": false,
+    "objectLiteralComputedProperties": true,
+    "objectLiteralDuplicateProperties": false,
+    "objectLiteralShorthandMethods": true,
+    "objectLiteralShorthandProperties": true,
+    "spread": true,
+    "superInFunctions": true,
+    "templateStrings": true,
+    "jsx": true
+  },
+  "rules": {
+    /**
+     * Strict mode
+     */
+    // babel inserts "use strict"; for us
+    // http://eslint.org/docs/rules/strict
+    "strict": [2, "never"],
+
+    /**
+     * ES6
+     */
+    "no-var": 2, // http://eslint.org/docs/rules/no-var
+
+    /**
+     * Variables
+     */
+    "no-shadow": 2, // http://eslint.org/docs/rules/no-shadow
+    "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    "no-const-assign": 2, // http://eslint.org/docs/rules/no-const-assign
+    "no-unused-vars": [2, { // http://eslint.org/docs/rules/no-unused-vars
+      "vars": "local",
+      "args": "after-used"
+    }],
+    "no-use-before-define": [2, "nofunc"], // http://eslint.org/docs/rules/no-use-before-define
+
+    /**
+     * Possible errors
+     */
+    "comma-dangle": [2, "never"], // http://eslint.org/docs/rules/comma-dangle
+    "no-cond-assign": [2, "always"], // http://eslint.org/docs/rules/no-cond-assign
+    "no-console": 1, // http://eslint.org/docs/rules/no-console
+    "no-debugger": 1, // http://eslint.org/docs/rules/no-debugger
+    "no-alert": 1, // http://eslint.org/docs/rules/no-alert
+    "no-constant-condition": 1, // http://eslint.org/docs/rules/no-constant-condition
+    "no-dupe-keys": 2, // http://eslint.org/docs/rules/no-dupe-keys
+    "no-duplicate-case": 2, // http://eslint.org/docs/rules/no-duplicate-case
+    "no-empty": 2, // http://eslint.org/docs/rules/no-empty
+    "no-ex-assign": 2, // http://eslint.org/docs/rules/no-ex-assign
+    "no-extra-boolean-cast": 0, // http://eslint.org/docs/rules/no-extra-boolean-cast
+    "no-extra-semi": 2, // http://eslint.org/docs/rules/no-extra-semi
+    "no-func-assign": 2, // http://eslint.org/docs/rules/no-func-assign
+    "no-inner-declarations": 2, // http://eslint.org/docs/rules/no-inner-declarations
+    "no-invalid-regexp": 2, // http://eslint.org/docs/rules/no-invalid-regexp
+    "no-irregular-whitespace": 2, // http://eslint.org/docs/rules/no-irregular-whitespace
+    "no-obj-calls": 2, // http://eslint.org/docs/rules/no-obj-calls
+    "no-sparse-arrays": 2, // http://eslint.org/docs/rules/no-sparse-arrays
+    "no-unreachable": 2, // http://eslint.org/docs/rules/no-unreachable
+    "use-isnan": 2, // http://eslint.org/docs/rules/use-isnan
+    "block-scoped-var": 0, // http://eslint.org/docs/rules/block-scoped-var
+
+    /**
+     * Best practices
+     */
+    "consistent-return": 2, // http://eslint.org/docs/rules/consistent-return
+    "curly": [2, "multi-line"], // http://eslint.org/docs/rules/curly
+    "default-case": 2, // http://eslint.org/docs/rules/default-case
+    "dot-notation": [2, { // http://eslint.org/docs/rules/dot-notation
+      "allowKeywords": true
+    }],
+    "eqeqeq": 2, // http://eslint.org/docs/rules/eqeqeq
+    "guard-for-in": 2, // http://eslint.org/docs/rules/guard-for-in
+    "no-caller": 2, // http://eslint.org/docs/rules/no-caller
+    "no-else-return": 2, // http://eslint.org/docs/rules/no-else-return
+    "no-eq-null": 2, // http://eslint.org/docs/rules/no-eq-null
+    "no-eval": 2, // http://eslint.org/docs/rules/no-eval
+    "no-extend-native": 2, // http://eslint.org/docs/rules/no-extend-native
+    "no-extra-bind": 2, // http://eslint.org/docs/rules/no-extra-bind
+    "no-fallthrough": 2, // http://eslint.org/docs/rules/no-fallthrough
+    "no-floating-decimal": 2, // http://eslint.org/docs/rules/no-floating-decimal
+    "no-implied-eval": 2, // http://eslint.org/docs/rules/no-implied-eval
+    "no-lone-blocks": 2, // http://eslint.org/docs/rules/no-lone-blocks
+    "no-loop-func": 2, // http://eslint.org/docs/rules/no-loop-func
+    "no-multi-str": 2, // http://eslint.org/docs/rules/no-multi-str
+    "no-native-reassign": 2, // http://eslint.org/docs/rules/no-native-reassign
+    "no-new": 2, // http://eslint.org/docs/rules/no-new
+    "no-new-func": 2, // http://eslint.org/docs/rules/no-new-func
+    "no-new-wrappers": 2, // http://eslint.org/docs/rules/no-new-wrappers
+    "no-octal": 2, // http://eslint.org/docs/rules/no-octal
+    "no-octal-escape": 2, // http://eslint.org/docs/rules/no-octal-escape
+    "no-param-reassign": 2, // http://eslint.org/docs/rules/no-param-reassign
+    "no-proto": 2, // http://eslint.org/docs/rules/no-proto
+    "no-redeclare": 2, // http://eslint.org/docs/rules/no-redeclare
+    "no-return-assign": 2, // http://eslint.org/docs/rules/no-return-assign
+    "no-script-url": 2, // http://eslint.org/docs/rules/no-script-url
+    "no-self-compare": 2, // http://eslint.org/docs/rules/no-self-compare
+    "no-sequences": 2, // http://eslint.org/docs/rules/no-sequences
+    "no-throw-literal": 2, // http://eslint.org/docs/rules/no-throw-literal
+    "no-with": 2, // http://eslint.org/docs/rules/no-with
+    "radix": 2, // http://eslint.org/docs/rules/radix
+    "vars-on-top": 2, // http://eslint.org/docs/rules/vars-on-top
+    "wrap-iife": [2, "any"], // http://eslint.org/docs/rules/wrap-iife
+    "yoda": 2, // http://eslint.org/docs/rules/yoda
+    "max-len": [2, 160, 2, {
+      "ignoreComments": true,
+      "ignoreUrls": true
+    }], // http://eslint.org/docs/rules/max-len
+    "valid-jsdoc": 2, // http://eslint.org/docs/rules/valid-jsdoc
+    "quote-props": [2, "consistent-as-needed"], // http://eslint.org/docs/rules/quote-props
+    "no-console": 2, // http://eslint.org/docs/rules/no-console
+
+    /**
+     * Style
+     */
+    "indent": [2, 2], // http://eslint.org/docs/rules/indent
+    "brace-style": [2, // http://eslint.org/docs/rules/brace-style
+      "1tbs", {
+        "allowSingleLine": true
+      }
+    ],
+    "quotes": [
+      2, "double", "avoid-escape" // http://eslint.org/docs/rules/quotes
+    ],
+    "camelcase": [2, { // http://eslint.org/docs/rules/camelcase
+      "properties": "always"
+    }],
+    "comma-spacing": [2, { // http://eslint.org/docs/rules/comma-spacing
+      "before": false,
+      "after": true
+    }],
+    "comma-style": [2, "last"], // http://eslint.org/docs/rules/comma-style
+    "eol-last": 2, // http://eslint.org/docs/rules/eol-last
+    "func-names": 0, // http://eslint.org/docs/rules/func-names
+    "func-style": [2, "declaration"], // http://eslint.org/docs/rules/func-style
+    "key-spacing": [2, { // http://eslint.org/docs/rules/key-spacing
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "new-cap": [0, { // http://eslint.org/docs/rules/new-cap  (turned off for now, as it complains on all Match)
+      "newIsCap": true,
+      "capIsNewExceptions": ["Match", "OneOf", "Optional"],
+    }],
+    "no-multiple-empty-lines": [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+      "max": 2
+    }],
+    "no-nested-ternary": 2, // http://eslint.org/docs/rules/no-nested-ternary
+    "no-new-object": 2, // http://eslint.org/docs/rules/no-new-object
+    "no-array-constructor": 2, // http://eslint.org/docs/rules/no-array-constructor
+    "no-spaced-func": 2, // http://eslint.org/docs/rules/no-spaced-func
+    "no-trailing-spaces": 2, // http://eslint.org/docs/rules/no-trailing-spaces
+    "no-extra-parens": 2, // http://eslint.org/docs/rules/no-extra-parens
+    "no-underscore-dangle": 0, // http://eslint.org/docs/rules/no-underscore-dangle
+    "one-var": [2, "never"], // http://eslint.org/docs/rules/one-var
+    "padded-blocks": [2, "never"], // http://eslint.org/docs/rules/padded-blocks
+    "semi": [2, "always"], // http://eslint.org/docs/rules/semi
+    "semi-spacing": [2, { // http://eslint.org/docs/rules/semi-spacing
+      "before": false,
+      "after": true
+    }],
+    "space-after-keywords": 2, // http://eslint.org/docs/rules/space-after-keywords
+    "space-before-blocks": 2, // http://eslint.org/docs/rules/space-before-blocks
+    "space-before-function-paren": [2, {
+      "anonymous": "always",
+      "named": "never"
+    }], // http://eslint.org/docs/rules/space-before-function-paren
+    "space-infix-ops": 2, // http://eslint.org/docs/rules/space-infix-ops
+    "space-return-throw-case": 2, // http://eslint.org/docs/rules/space-return-throw-case
+    "space-in-parens": [2, "never"], // http://eslint.org/docs/rules/space-in-parens
+    "spaced-comment": [2, "always"], // http://eslint.org/docs/rules/spaced-comment
+  }
+}

--- a/client/templates/checkout/payflowForm.html
+++ b/client/templates/checkout/payflowForm.html
@@ -34,7 +34,8 @@
         <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
         {{/if}}
       </div>
-
+    </div>
+    <div class="row">
       <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
         <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
         {{>afFieldInput name="cvv" placeholder="CVV"}}

--- a/client/templates/checkout/payflowForm.js
+++ b/client/templates/checkout/payflowForm.js
@@ -99,6 +99,9 @@ AutoForm.addHooks("paypal-payment-form", {
             storedCard: storedCard,
             method: transaction.response.payer.payment_method,
             transactionId: transaction.response.transactions[0].related_resources[0].authorization.id,
+            metadata: {
+              authorizationId: transaction.response.transactions[0].related_resources[0].authorization.id
+            },
             amount: Number(transaction.response.transactions[0].amount.total),
             status: normalizedStatus,
             mode: normalizedMode,

--- a/package.js
+++ b/package.js
@@ -37,6 +37,7 @@ Package.onUse(function (api, where) {
   api.addFiles([
     "server/register.js", // register as a reaction package
     "server/browserPolicy.js", // set browser policy to allow PayPal scripts and images
+    "server/methods/common.js", // Common methods for managing paypal things
     "server/methods/express.js", // server methods for express checkout
     "server/methods/payflow.js" // server methods for payflow
   ], "server");

--- a/server/methods/common.js
+++ b/server/methods/common.js
@@ -1,0 +1,80 @@
+
+const paypal = Npm.require("paypal-rest-sdk");
+
+Meteor.methods({
+
+  "paypal/refund/create": function (paymentMethod, amount) {
+    check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
+    check(amount, Number);
+    this.unblock();
+
+    paypal.configure(Meteor.Paypal.payflowAccountOptions());
+
+    let createRefund = Meteor.wrapAsync(paypal.capture.refund, paypal.capture);
+    let result;
+
+    try {
+      let response = createRefund(paymentMethod.metadata.captureId, {
+        amount: {
+          total: amount,
+          currency: "USD"
+        }
+      });
+
+      result = {
+        saved: true,
+        type: "refund",
+        created: response.create_time,
+        amount: response.amount.total,
+        currency: response.amount.currency,
+        rawTransaction: response
+      };
+    } catch (e) {
+      result = {
+        saved: false,
+        error: e
+      };
+    }
+    console.log("Attempt to make a refund", result);
+
+    return result;
+  },
+
+  "paypal/refund/list": function (paymentMethod) {
+    check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
+    this.unblock();
+
+    paypal.configure(Meteor.Paypal.payflowAccountOptions());
+
+    let listPayments = Meteor.wrapAsync(paypal.payment.get, paypal.payment);
+    let result;
+
+    try {
+      let response = listPayments(paymentMethod.metadata.parentPaymentId);
+      result = [];
+
+      for (let transaction of response.transactions) {
+        for (let resource of transaction.related_resources) {
+          if (_.isObject(resource.refund)) {
+            if (resource.refund.state === "completed") {
+              result.push({
+                type: "refund",
+                created: resource.refund.create_time,
+                amount: Math.abs(resource.refund.amount.total),
+                currency: resource.refund.amount.currency,
+                rawTransaction: resource.refund
+              });
+            }
+          }
+        }
+      }
+    } catch (e) {
+      ReactionCore.Log.warn("Couln't get paypal payment info", e);
+      result = {
+        error: e
+      };
+    }
+
+    return result;
+  }
+});

--- a/server/methods/payflow.js
+++ b/server/methods/payflow.js
@@ -37,17 +37,19 @@ Meteor.methods({
    * @param  {Object} paymentMethod A PaymentMethod object
    * @return {Object} results from PayPal normalized
    */
-  "paypal/payment/capture": function(paymentMethod) {
+  "paypal/payment/capture": function (paymentMethod) {
     check(paymentMethod, ReactionCore.Schemas.PaymentMethod);
     this.unblock();
 
     PayFlow.configure(Meteor.Paypal.payflowAccountOptions());
-
     let result;
+
+    // TODO: This should be changed to some ReactionCore method
+    const shop = ReactionCore.Collections.Shops.findOne(ReactionCore.getShopId());
     const wrappedFunc = Meteor.wrapAsync(PayFlow.authorization.capture, PayFlow.authorization);
     const captureDetails = {
       amount: {
-        currency: "USD",
+        currency: shop.currency,
         total: parseFloat(paymentMethod.amount, 10)
       },
       is_final_capture: true // eslint-disable-line camelcase


### PR DESCRIPTION
reactioncommerce/reaction#215

**Updated Paypal payment capture (BREAKING)**
Paypal payment capture method has been updated to accept a whole
paymentMethod object to better handle differences between payment
providers.

Also, it now returns more metadata with associated id's from the Paypal
transaction, which are needed to process and list returns.

**Other Changes**
- Added common methods for creating and listing refunds
- Added metadata object with authorizationId
- Moved CVV into its own row
Added .eslint and .editorconfig